### PR TITLE
Sql editor null reference fix

### DIFF
--- a/Source/GuidFac/GuidFac.csproj
+++ b/Source/GuidFac/GuidFac.csproj
@@ -72,6 +72,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.2.32505.113" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.32505.173" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -80,6 +81,18 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <Reference Include="Microsoft.VisualStudio.Diagnostics.Assert">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.Assert.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Platform.WindowManagement">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\Microsoft.VisualStudio.Platform.WindowManagement.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.ViewManager">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\Microsoft.VisualStudio.Shell.ViewManager.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -229,7 +242,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Source/GuidFac/GuidFacWindow.xaml.cs
+++ b/Source/GuidFac/GuidFacWindow.xaml.cs
@@ -6,10 +6,8 @@ using System;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
-using System.Windows.Media;
 
 using FScreen = System.Windows.Forms.Screen;
-
 /// <summary>
 /// Interaction logic for GuidFacWindow.xaml
 /// </summary>
@@ -22,19 +20,18 @@ public partial class GuidFacWindow : DialogWindow
     private Guid currentGuid;
     private readonly RadioButtonSelector buttonSelector;
 
-    public GuidFacWindow(Point pos, UIElement host, GuidFacConfig config)
+    public GuidFacWindow(Point pos, Window parentWindow, GuidFacConfig config)
     {
         InitializeComponent();
 
         this.config = config;
 
-        var window = FindWindow(host);
-        this.Owner = window;
-        var desiredScreenLocation = host.PointToScreen(pos);
-        var windowOrigin = host.PointToScreen(new Point(0, 0));
+        this.Owner = parentWindow;
+        var desiredScreenLocation = parentWindow.PointToScreen(pos);
+        var windowOrigin = parentWindow.PointToScreen(new Point(0, 0));
         var lowerRightLocation = new Point(pos.X + this.Width, pos.Y + this.Height);
-        var lowerRightScreenLocation = host.PointToScreen(lowerRightLocation) - windowOrigin;
-        var screen = FScreen.FromHandle(new WindowInteropHelper(window).Handle);
+        var lowerRightScreenLocation = parentWindow.PointToScreen(lowerRightLocation) - windowOrigin;
+        var screen = FScreen.FromHandle(new WindowInteropHelper(parentWindow).Handle);
         var area = screen.WorkingArea;
 
         if (lowerRightScreenLocation.Y + MakeNiceMargin > area.Height)
@@ -110,17 +107,6 @@ public partial class GuidFacWindow : DialogWindow
         e.Handled = true;
     }
 
-    private Window FindWindow(UIElement element)
-    {
-        var parent = VisualTreeHelper.GetParent(element);
-        while (parent != null && parent is not Window)
-        {
-            parent = VisualTreeHelper.GetParent(parent);
-        }
-
-        return (Window)parent;
-    }
-
     private void Update(bool keepIndex = true)
     {
         var gfm = this.GetGuidFormatFromButtonStates();
@@ -170,11 +156,12 @@ public partial class GuidFacWindow : DialogWindow
 
     private GuidFormat GetGuidFormatFromButtonStates()
     {
-        GuidFormat gfm = GuidFormat.Both;
-        if (this.radioButtonLower.IsChecked == true) { gfm = GuidFormat.Lower; }
-        else if (this.radioButtonUpper.IsChecked == true) { gfm = GuidFormat.Upper; }
-
-        return gfm;
+        if (this.radioButtonLower.IsChecked == true)
+        { return GuidFormat.Lower; }
+        else if (this.radioButtonUpper.IsChecked == true)
+        { return GuidFormat.Upper; }
+        else
+        { return GuidFormat.Both; }
     }
 
     private void OnListViewFormatsMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Source/GuidFac/Properties/AssemblyInfo.cs
+++ b/Source/GuidFac/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GuidFac")]
@@ -21,15 +21,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Revision and Build Numbers 
+// You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
 [assembly: AssemblyVersion("1.3.0")]
 [assembly: AssemblyFileVersion("1.3.0.0")]
-
-
-


### PR DESCRIPTION
Fixed issue with recursive FindWindow implementation

In SSDT SQL editor window it does not work as it does not have a final root window parent.
Used private Visual Studio API instead.

Review after C# 10 is merged